### PR TITLE
Introduce `RetrievalModel` abstract base class

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ data_path = util.download_and_unzip(url, out_dir)
 corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="test")
 
 #### Load the SBERT model and retrieve using cosine-similarity
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16)
-retriever = EvaluateRetrieval(model, score_function="cos_sim") # or "dot" for dot-product
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16, score_function="cos_sim") # or "dot" for dot-product
+retriever = EvaluateRetrieval(model)
 results = retriever.retrieve(corpus, queries)
 
 #### Evaluate your model with NDCG@k, MAP@K, Recall@K and Precision@K  where k = [1,3,5,10,100,1000] 
@@ -380,8 +380,8 @@ from beir.retrieval import models
 from beir.retrieval.evaluation import EvaluateRetrieval
 from beir.retrieval.search.dense import DenseRetrievalExactSearch as DRES
 
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16)
-retriever = EvaluateRetrieval(model, score_function="cos_sim") # or "dot" for dot-product
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16, score_function="cos_sim") # or "dot" for dot-product
+retriever = EvaluateRetrieval(model)
 ```
 
 ### Reranking using Cross-Encoder model

--- a/beir/retrieval/evaluation.py
+++ b/beir/retrieval/evaluation.py
@@ -17,7 +17,7 @@ class EvaluateRetrieval:
     def retrieve(self, corpus: Dict[str, Dict[str, str]], queries: Dict[str, str], **kwargs) -> Dict[str, Dict[str, float]]:
         if not self.retrieval_model:
             raise ValueError("Model/Technique has not been provided!")
-        # score_function here is to stay backwart compatible with previous implementations that did not use the score_function
+        # purpose of score_function here is to ensure backward compatibility with previous extensions that did not use the score_function
         return self.retrieval_model.search(corpus=corpus, queries=queries, top_k=self.top_k, score_function=None, **kwargs)
     
     def rerank(self, 

--- a/beir/retrieval/evaluation.py
+++ b/beir/retrieval/evaluation.py
@@ -17,7 +17,8 @@ class EvaluateRetrieval:
     def retrieve(self, corpus: Dict[str, Dict[str, str]], queries: Dict[str, str], **kwargs) -> Dict[str, Dict[str, float]]:
         if not self.retrieval_model:
             raise ValueError("Model/Technique has not been provided!")
-        return self.retrieval_model.search(corpus=corpus, queries=queries, top_k=self.top_k, **kwargs)
+        # score_function here is to stay backwart compatible with previous implementations that did not use the score_function
+        return self.retrieval_model.search(corpus=corpus, queries=queries, top_k=self.top_k, score_function=None, **kwargs)
     
     def rerank(self, 
             corpus: Dict[str, Dict[str, str]], 

--- a/beir/retrieval/evaluation.py
+++ b/beir/retrieval/evaluation.py
@@ -1,26 +1,23 @@
 import pytrec_eval
 import logging
 from typing import Type, List, Dict, Union, Tuple
-from .search.dense import DenseRetrievalExactSearch as DRES
-from .search.dense import DenseRetrievalFaissSearch as DRFS
-from .search.lexical import BM25Search as BM25
-from .search.sparse import SparseSearch as SS
+
+from beir.retrieval.search.base import RetrievalModel
 from .custom_metrics import mrr, recall_cap, hole, top_k_accuracy
 
 logger = logging.getLogger(__name__)
 
 class EvaluateRetrieval:
     
-    def __init__(self, retriever: Union[Type[DRES], Type[DRFS], Type[BM25], Type[SS]] = None, k_values: List[int] = [1,3,5,10,100,1000], score_function: str = "cos_sim"):
+    def __init__(self, retrieval_model: RetrievalModel, k_values: List[int] = [1,3,5,10,100,1000]):
         self.k_values = k_values
         self.top_k = max(k_values)
-        self.retriever = retriever
-        self.score_function = score_function
+        self.retrieval_model = retrieval_model
             
     def retrieve(self, corpus: Dict[str, Dict[str, str]], queries: Dict[str, str], **kwargs) -> Dict[str, Dict[str, float]]:
-        if not self.retriever:
+        if not self.retrieval_model:
             raise ValueError("Model/Technique has not been provided!")
-        return self.retriever.search(corpus, queries, self.top_k, self.score_function, **kwargs)
+        return self.retrieval_model.search(corpus=corpus, queries=queries, top_k=self.top_k, **kwargs)
     
     def rerank(self, 
             corpus: Dict[str, Dict[str, str]], 
@@ -38,7 +35,7 @@ class EvaluateRetrieval:
                 for doc_id in results[query_id]:
                     new_corpus[doc_id] = corpus[doc_id]
                     
-        return self.retriever.search(new_corpus, queries, top_k, self.score_function)
+        return self.retrieval_model.search(corpus=new_corpus, queries=queries, top_k=top_k)
 
     @staticmethod
     def evaluate(qrels: Dict[str, Dict[str, int]], 

--- a/beir/retrieval/evaluation.py
+++ b/beir/retrieval/evaluation.py
@@ -2,7 +2,7 @@ import pytrec_eval
 import logging
 from typing import Type, List, Dict, Union, Tuple
 
-from beir.retrieval.search.base import RetrievalModel
+from beir.retrieval.search import RetrievalModel
 from .custom_metrics import mrr, recall_cap, hole, top_k_accuracy
 
 logger = logging.getLogger(__name__)

--- a/beir/retrieval/search/__init__.py
+++ b/beir/retrieval/search/__init__.py
@@ -1,0 +1,1 @@
+from .base import RetrievalModel

--- a/beir/retrieval/search/base.py
+++ b/beir/retrieval/search/base.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+from typing import Dict
+
+
+class RetrievalModel(ABC):
+    @abstractmethod
+    def search(self, 
+        corpus: Dict[str, Dict[str, str]],
+        queries: Dict[str, str],
+        top_k: int,
+        **kwargs) -> Dict[str, Dict[str, float]]:
+        pass

--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -1,15 +1,16 @@
+from beir.retrieval.search.base import RetrievalModel
 from .util import cos_sim, dot_score
 import logging
 import sys
 import torch
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 #Parent class for any dense model
-class DenseRetrievalExactSearch:
+class DenseRetrievalExactSearch(RetrievalModel):
     
-    def __init__(self, model, batch_size: int = 128, corpus_chunk_size: int = 50000, **kwargs):
+    def __init__(self, model, batch_size: int = 128, corpus_chunk_size: int = 50000, score_function: str = "cos_sim", **kwargs):
         #model is class that provides encode_corpus() and encode_queries()
         self.model = model
         self.batch_size = batch_size
@@ -19,18 +20,18 @@ class DenseRetrievalExactSearch:
         self.show_progress_bar = True #TODO: implement no progress bar if false
         self.convert_to_tensor = True
         self.results = {}
+        self.score_function = score_function
     
     def search(self, 
                corpus: Dict[str, Dict[str, str]], 
                queries: Dict[str, str], 
-               top_k: List[int], 
-               score_function: str,
+               top_k: int, 
                return_sorted: bool = False, **kwargs) -> Dict[str, Dict[str, float]]:
         #Create embeddings for all queries using model.encode_queries()
         #Runs semantic search against the corpus embeddings
         #Returns a ranked list with the corpus ids
-        if score_function not in self.score_functions:
-            raise ValueError("score function: {} must be either (cos_sim) for cosine similarity or (dot) for dot product".format(score_function))
+        if self.score_function not in self.score_functions:
+            raise ValueError("score function: {} must be either (cos_sim) for cosine similarity or (dot) for dot product".format(self.score_function))
             
         logger.info("Encoding Queries...")
         query_ids = list(queries.keys())
@@ -45,7 +46,7 @@ class DenseRetrievalExactSearch:
         corpus = [corpus[cid] for cid in corpus_ids]
 
         logger.info("Encoding Corpus in batches... Warning: This might take a while!")
-        logger.info("Scoring Function: {} ({})".format(self.score_function_desc[score_function], score_function))
+        logger.info("Scoring Function: {} ({})".format(self.score_function_desc[self.score_function], self.score_function))
 
         itr = range(0, len(corpus), self.corpus_chunk_size)
 
@@ -62,7 +63,7 @@ class DenseRetrievalExactSearch:
                 )
 
             #Compute similarites using either cosine-similarity or dot product
-            cos_scores = self.score_functions[score_function](query_embeddings, sub_corpus_embeddings)
+            cos_scores = self.score_functions[self.score_function](query_embeddings, sub_corpus_embeddings)
             cos_scores[torch.isnan(cos_scores)] = -1
 
             #Get top-k values

--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -3,7 +3,7 @@ from .util import cos_sim, dot_score
 import logging
 import sys
 import torch
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 logger = logging.getLogger(__name__)
 

--- a/beir/retrieval/search/lexical/bm25_search.py
+++ b/beir/retrieval/search/lexical/bm25_search.py
@@ -2,7 +2,7 @@ from beir.retrieval.search.base import RetrievalModel
 from .elastic_search import ElasticSearch
 import tqdm
 import time
-from typing import List, Dict, Optional
+from typing import List, Dict
 
 def sleep(seconds):
     if seconds: time.sleep(seconds) 

--- a/beir/retrieval/search/lexical/bm25_search.py
+++ b/beir/retrieval/search/lexical/bm25_search.py
@@ -1,12 +1,13 @@
+from beir.retrieval.search.base import RetrievalModel
 from .elastic_search import ElasticSearch
 import tqdm
 import time
-from typing import List, Dict
+from typing import List, Dict, Optional
 
 def sleep(seconds):
     if seconds: time.sleep(seconds) 
 
-class BM25Search:
+class BM25Search(RetrievalModel):
     def __init__(self, index_name: str, hostname: str = "localhost", keys: Dict[str, str] = {"title": "title", "body": "txt"}, language: str = "english",
                  batch_size: int = 128, timeout: int = 100, retry_on_timeout: bool = True, maxsize: int = 24, number_of_shards: int = "default", 
                  initialize: bool = True, sleep_for: int = 2):
@@ -33,7 +34,7 @@ class BM25Search:
         sleep(self.sleep_for)
         self.es.create_index()
     
-    def search(self, corpus: Dict[str, Dict[str, str]], queries: Dict[str, str], top_k: List[int], *args, **kwargs) -> Dict[str, Dict[str, float]]:
+    def search(self, corpus: Dict[str, Dict[str, str]], queries: Dict[str, str], top_k: int, **kwargs) -> Dict[str, Dict[str, float]]:
         
         # Index the corpus within elastic-search
         # False, if the corpus has been already indexed

--- a/beir/retrieval/search/sparse/sparse_search.py
+++ b/beir/retrieval/search/sparse/sparse_search.py
@@ -1,11 +1,13 @@
 from tqdm.autonotebook import trange
-from typing import List, Dict, Union, Tuple
+from typing import List, Dict, Optional, Union, Tuple
 import logging
 import numpy as np
 
+from beir.retrieval.search.base import RetrievalModel
+
 logger = logging.getLogger(__name__)
 
-class SparseSearch:
+class SparseSearch(RetrievalModel):
     
     def __init__(self, model, batch_size: int = 16, **kwargs):
         self.model = model
@@ -17,9 +19,8 @@ class SparseSearch:
         corpus: Dict[str, Dict[str, str]], 
         queries: Dict[str, str], 
         top_k: int,
-        score_function: str, 
         query_weights: bool = False, 
-        *args, **kwargs) -> Dict[str, Dict[str, float]]:
+        **kwargs) -> Dict[str, Dict[str, float]]:
         
         doc_ids = list(corpus.keys())
         query_ids = list(queries.keys())

--- a/beir/retrieval/search/sparse/sparse_search.py
+++ b/beir/retrieval/search/sparse/sparse_search.py
@@ -1,5 +1,5 @@
 from tqdm.autonotebook import trange
-from typing import List, Dict, Optional, Union, Tuple
+from typing import List, Dict, Union, Tuple
 import logging
 import numpy as np
 

--- a/examples/benchmarking/benchmark_bm25.py
+++ b/examples/benchmarking/benchmark_bm25.py
@@ -49,7 +49,7 @@ model = BM25(index_name=index_name, hostname=hostname)
 bm25 = EvaluateRetrieval(model)
  
 #### Index 1M passages into the index (seperately)
-bm25.retriever.index(corpus_new)
+bm25.retrieval_model.index(corpus_new)
 
 #### Saving benchmark times
 time_taken_all = {}
@@ -59,7 +59,7 @@ for query_id in query_ids:
     
     #### Measure time to retrieve top-10 BM25 documents using single query latency
     start = datetime.datetime.now()
-    results = bm25.retriever.es.lexical_search(text=query, top_hits=10) 
+    results = bm25.retrieval_model.es.lexical_search(text=query, top_hits=10) 
     end = datetime.datetime.now()
     
     #### Measuring time taken in ms (milliseconds)

--- a/examples/benchmarking/benchmark_bm25_ce_reranking.py
+++ b/examples/benchmarking/benchmark_bm25_ce_reranking.py
@@ -52,7 +52,7 @@ model = BM25(index_name=index_name, hostname=hostname)
 bm25 = EvaluateRetrieval(model)
  
 #### Index 1M passages into the index (seperately)
-bm25.retriever.index(corpus_new)
+bm25.retrieval_model.index(corpus_new)
 
 #### Reranking using Cross-Encoder model
 reranker = CrossEncoder('cross-encoder/ms-marco-electra-base')
@@ -65,7 +65,7 @@ for query_id in query_ids:
     
     #### Measure time to retrieve top-100 BM25 documents using single query latency
     start = datetime.datetime.now()
-    results = bm25.retriever.es.lexical_search(text=query, top_hits=100) 
+    results = bm25.retrieval_model.es.lexical_search(text=query, top_hits=100) 
     
     #### Measure time to rerank top-100 BM25 documents using CE
     sentence_pairs = [[queries[query_id], corpus_texts[hit[0]]] for hit in results["hits"]]

--- a/examples/retrieval/evaluation/custom/evaluate_custom_dataset.py
+++ b/examples/retrieval/evaluation/custom/evaluate_custom_dataset.py
@@ -56,9 +56,9 @@ qrels = {
 #### Sentence-Transformer ####
 #### Provide any pretrained sentence-transformers model path
 #### Complete list - https://www.sbert.net/docs/pretrained_models.html
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"))
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), score_function="cos_sim")
 
-retriever = EvaluateRetrieval(model, score_function="cos_sim")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/custom/evaluate_custom_dataset_files.py
+++ b/examples/retrieval/evaluation/custom/evaluate_custom_dataset_files.py
@@ -54,9 +54,9 @@ corpus, queries, qrels = GenericDataLoader(
 #### Sentence-Transformer ####
 #### Provide any pretrained sentence-transformers model path
 #### Complete list - https://www.sbert.net/docs/pretrained_models.html
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"))
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), score_function="cos_sim")
 
-retriever = EvaluateRetrieval(model, score_function="cos_sim")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/custom/evaluate_custom_metrics.py
+++ b/examples/retrieval/evaluation/custom/evaluate_custom_metrics.py
@@ -35,8 +35,8 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 #### The model was fine-tuned using cosine-similarity.
 #### Complete list - https://www.sbert.net/docs/pretrained_models.html
 
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16)
-retriever = EvaluateRetrieval(model, score_function="cos_sim")
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16, score_function="cos_sim")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/custom/evaluate_custom_model.py
+++ b/examples/retrieval/evaluation/custom/evaluate_custom_model.py
@@ -43,9 +43,9 @@ data_path = util.download_and_unzip(url, out_dir)
 corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="test")
 
 #### Provide your custom model class name --> HERE
-model = DRES(YourCustomModel(model_path="your-custom-model-path"))
+model = DRES(YourCustomModel(model_path="your-custom-model-path"), score_function="cos_sim") # or "dot" if you wish dot-product
 
-retriever = EvaluateRetrieval(model, score_function="cos_sim") # or "dot" if you wish dot-product
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/dense/evaluate_ance.py
+++ b/examples/retrieval/evaluation/dense/evaluate_ance.py
@@ -35,8 +35,8 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 # MSMARCO Dev Passage Retrieval ANCE(FirstP) 600K model from ANCE.
 # The ANCE model was fine-tuned using dot-product (dot) function.
 
-model = DRES(models.SentenceBERT("msmarco-roberta-base-ance-firstp"))
-retriever = EvaluateRetrieval(model, score_function="dot")
+model = DRES(models.SentenceBERT("msmarco-roberta-base-ance-firstp"), score_function="dot")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/dense/evaluate_bpr.py
+++ b/examples/retrieval/evaluation/dense/evaluate_bpr.py
@@ -75,8 +75,9 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 # The model was fine-tuned using CLS Pooling and dot-product!
 # Open-sourced binary code SBERT model trained on MSMARCO to be made available soon!
 
+score_function = "dot" # or cos_sim for cosine similarity
 model = models.BinarySentenceBERT("msmarco-distilbert-base-tas-b") # Proxy for now, soon coming up BPR models trained on MSMARCO!
-faiss_search = BinaryFaissSearch(model, batch_size=128)
+faiss_search = BinaryFaissSearch(model, batch_size=128, score_function=score_function)
 
 #### Load faiss index from file or disk ####
 # We need two files to be present within the input_dir!
@@ -96,8 +97,7 @@ if os.path.isdir(input_dir):
 # Please Note, Reranking here is done with a bi-encoder which is quite faster compared to cross-encoders.
 # Reranking is advised by the original paper as its quite fast, efficient and leads to decent performances.
 
-score_function = "dot" # or cos_sim for cosine similarity
-retriever = EvaluateRetrieval(faiss_search, score_function=score_function)
+retriever = EvaluateRetrieval(faiss_search)
 
 rerank = True                       # False would only retrieve top-k documents based on hamming distance.
 binary_k = 1000                     # binary_k value denotes documents reranked for each query.

--- a/examples/retrieval/evaluation/dense/evaluate_dim_reduction.py
+++ b/examples/retrieval/evaluation/dense/evaluate_dim_reduction.py
@@ -66,7 +66,7 @@ base_index = faiss.IndexFlatIP(output_dimension)
 faiss_search = PCAFaissSearch(model,
                               base_index=base_index,
                               output_dimension=output_dimension,
-                              batch_size=128)
+                              batch_size=128, score_function="dot") # or "cos_sim"
 
 #######################################################################
 #### PCA: Principal Component Analysis (with Product Quantization) ####
@@ -98,7 +98,7 @@ if os.path.exists(os.path.join(input_dir, "{}.{}.faiss".format(prefix, ext))):
     faiss_search.load(input_dir=input_dir, prefix=prefix, ext=ext)
 
 #### Retrieve dense results (format of results is identical to qrels)
-retriever = EvaluateRetrieval(faiss_search, score_function="dot") # or "cos_sim"
+retriever = EvaluateRetrieval(faiss_search)
 results = retriever.retrieve(corpus, queries)
 
 ### Save faiss index into file or disk ####

--- a/examples/retrieval/evaluation/dense/evaluate_faiss_dense.py
+++ b/examples/retrieval/evaluation/dense/evaluate_faiss_dense.py
@@ -57,7 +57,7 @@ model = models.SentenceBERT(model_path)
 ########################################################
 
 faiss_search = FlatIPFaissSearch(model, 
-                                 batch_size=128)
+                                 batch_size=128, score_function="dot") # or "cos_sim"
 
 ######################################################
 #### PQ: Product Quantization (Exhaustive Search) ####
@@ -91,7 +91,7 @@ if os.path.exists(os.path.join(input_dir, "{}.{}.faiss".format(prefix, ext))):
     faiss_search.load(input_dir=input_dir, prefix=prefix, ext=ext)
 
 #### Retrieve dense results (format of results is identical to qrels)
-retriever = EvaluateRetrieval(faiss_search, score_function="dot") # or "cos_sim"
+retriever = EvaluateRetrieval(faiss_search)
 results = retriever.retrieve(corpus, queries)
 
 ### Save faiss index into file or disk ####

--- a/examples/retrieval/evaluation/dense/evaluate_sbert.py
+++ b/examples/retrieval/evaluation/dense/evaluate_sbert.py
@@ -35,8 +35,8 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 #### The model was fine-tuned using cosine-similarity.
 #### Complete list - https://www.sbert.net/docs/pretrained_models.html
 
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16)
-retriever = EvaluateRetrieval(model, score_function="cos_sim")
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=16, score_function="cos_sim")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/dense/evaluate_useqa.py
+++ b/examples/retrieval/evaluation/dense/evaluate_useqa.py
@@ -36,8 +36,8 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 # USE-QA implements a two-tower strategy i.e. encoding the query and document seperately.
 # USE-QA provides normalized embeddings, so you can use either dot product or cosine-similarity
 
-model = DRES(models.UseQA("https://tfhub.dev/google/universal-sentence-encoder-qa/3"))
-retriever = EvaluateRetrieval(model, score_function="dot")
+model = DRES(models.UseQA("https://tfhub.dev/google/universal-sentence-encoder-qa/3"), score_function="dot")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/reranking/evaluate_bm25_sbert_reranking.py
+++ b/examples/retrieval/evaluation/reranking/evaluate_bm25_sbert_reranking.py
@@ -37,8 +37,8 @@ retriever = EvaluateRetrieval(model)
 results = retriever.retrieve(corpus, queries)
 
 #### Reranking top-100 docs using Dense Retriever model 
-model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=128)
-dense_retriever = EvaluateRetrieval(model, score_function="cos_sim", k_values=[1,3,5,10,100])
+model = DRES(models.SentenceBERT("msmarco-distilbert-base-v3"), batch_size=128, score_function="cos_sim")
+dense_retriever = EvaluateRetrieval(model, k_values=[1,3,5,10,100])
 
 #### Retrieve dense results (format of results is identical to qrels)
 rerank_results = dense_retriever.rerank(corpus, queries, results, top_k=100)

--- a/examples/retrieval/evaluation/sparse/evaluate_splade.py
+++ b/examples/retrieval/evaluation/sparse/evaluate_splade.py
@@ -44,8 +44,8 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 # NOTE: this version only works for max agg in SPLADE!
 
 model_path = "splade/weights/distilsplade_max"
-model = DRES(models.SPLADE(model_path), batch_size=128)
-retriever = EvaluateRetrieval(model, score_function="dot")
+model = DRES(models.SPLADE(model_path), batch_size=128, score_function="dot")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries)

--- a/examples/retrieval/evaluation/sparse/evaluate_unicoil.py
+++ b/examples/retrieval/evaluation/sparse/evaluate_unicoil.py
@@ -42,8 +42,8 @@ corpus, queries, qrels = GenericDataLoader(data_folder=data_path).load(split="te
 # For more details on how the model works, please refer: (https://arxiv.org/abs/2106.14807)
 
 model_path = "castorini/unicoil-d2q-msmarco-passage"
-model = SparseSearch(models.UniCOIL(model_path=model_path), batch_size=32)
-retriever = EvaluateRetrieval(model, score_function="dot")
+model = SparseSearch(models.UniCOIL(model_path=model_path), batch_size=32, score_function="dot")
+retriever = EvaluateRetrieval(model)
 
 #### Retrieve dense results (format of results is identical to qrels)
 results = retriever.retrieve(corpus, queries, query_weights=True)

--- a/examples/retrieval/training/train_sbert_BM25_hardnegs.py
+++ b/examples/retrieval/training/train_sbert_BM25_hardnegs.py
@@ -68,7 +68,7 @@ model = BM25(index_name=index_name, hostname=hostname, initialize=initialize, nu
 bm25 = EvaluateRetrieval(model)
 
 #### Index passages into the index (seperately)
-bm25.retriever.index(corpus)
+bm25.retrieval_model.index(corpus)
 
 triplets = []
 qids = list(qrels) 
@@ -79,7 +79,7 @@ for idx in tqdm.tqdm(range(len(qids)), desc="Retrieve Hard Negatives using BM25"
     query_id, query_text = qids[idx], queries[qids[idx]]
     pos_docs = [doc_id for doc_id in qrels[query_id] if qrels[query_id][doc_id] > 0]
     pos_doc_texts = [corpus[doc_id]["title"] + " " + corpus[doc_id]["text"] for doc_id in pos_docs]
-    hits = bm25.retriever.es.lexical_multisearch(texts=pos_doc_texts, top_hits=hard_negatives_max+1)
+    hits = bm25.retrieval_model.es.lexical_multisearch(texts=pos_doc_texts, top_hits=hard_negatives_max+1)
     for (pos_text, hit) in zip(pos_doc_texts, hits):
         for (neg_id, _) in hit.get("hits"):
             if neg_id not in pos_docs:


### PR DESCRIPTION
**Proposed Changes:**
- add `RetrievalModel` ABC
- make `SparseSearch`, `BM25Search`, `DenseRetrievalFaissSearch` and `DenseRetrievalExactSearch` inherit from `RetrievalModel`
- `EvaluateRetrieval` receives `RetrievalModel` as param
- rename `retriever` to `retrieval_model` in `EvaluateRetrieval`
- move `score_function` param from `EvaluateRetrieval` to  `DenseRetrievalFaissSearch` and `DenseRetrievalExactSearch`
- adjust code that set `score_function` on `EvaluateRetrieval` previously

closes https://github.com/beir-cellar/beir/issues/84