### PR TITLE
add option ignore_identical_ids in evaluation, important for Pyserini (+CE) on ArguAna

### DIFF
--- a/beir/retrieval/evaluation.py
+++ b/beir/retrieval/evaluation.py
@@ -43,8 +43,20 @@ class EvaluateRetrieval:
     @staticmethod
     def evaluate(qrels: Dict[str, Dict[str, int]], 
                  results: Dict[str, Dict[str, float]], 
-                 k_values: List[int]) -> Tuple[Dict[str, float], Dict[str, float], Dict[str, float], Dict[str, float]]:
-    
+                 k_values: List[int],
+                 ignore_identical_ids: bool=True) -> Tuple[Dict[str, float], Dict[str, float], Dict[str, float], Dict[str, float]]:
+        
+        if ignore_identical_ids:
+            logging.info('Preprocessing the results to remove identical IDs. This is important for ArguAna and Quora')
+            popped = []
+            for qid, rels in results.items():
+                for pid in list(rels):
+                    if qid == pid:
+                        results[qid].pop(pid)
+                        popped.append(pid)
+            if len(popped):
+                logging.info(f'Removed {len(popped)} pairs. Examples: {popped[:3]}')
+
         ndcg = {}
         _map = {}
         recall = {}


### PR DESCRIPTION
By setting this new option, identical IDs between queries and documents will be ignored. In my evaluation, I found this will improve Pyserini / Pyserini + CE / DocT5Query (Pyserini) from 31.5/31.1/34.9 to 41.4/41.7/46.9 (nDCG@10%) on ArguAna. No influence on Quora was found. For dense models + exact search, there would be also no influence, since identical IDs would have already been removed in the exact search step.