### PR TITLE
fix cos_scores_top_k_idx when using DRPES

### DIFF
--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -42,11 +42,9 @@ if importlib.util.find_spec("evaluate") is not None:
                 if batch_index[i] == -1:
                     del cos_scores_top_k_values[i]
                     del cos_scores_top_k_idx[i]
-            batch_index = [e for e in batch_index if e != -1]
-            batch_index = np.repeat(batch_index, len(cos_scores_top_k_values[0]))
             cos_scores_top_k_values = np.concatenate(cos_scores_top_k_values, axis=0)
             cos_scores_top_k_idx = np.concatenate(cos_scores_top_k_idx, axis=0)
-            return cos_scores_top_k_values, cos_scores_top_k_idx, batch_index[:len(cos_scores_top_k_values)]
+            return cos_scores_top_k_values, cos_scores_top_k_idx
 
         def warmup(self):
             """
@@ -147,8 +145,7 @@ class DenseRetrievalParallelExactSearch:
         metric.filelock = FileLock(os.path.join(metric.data_dir, f"{metric.experiment_id}-{metric.num_process}-{metric.process_id}.arrow.lock"))
         metric.cache_file_name = os.path.join(metric.data_dir, f"{metric.experiment_id}-{metric.num_process}-{metric.process_id}.arrow")
 
-        cos_scores_top_k_values, cos_scores_top_k_idx, chunk_ids = metric.compute()
-        cos_scores_top_k_idx = (cos_scores_top_k_idx.T + chunk_ids * self.corpus_chunk_size).T
+        cos_scores_top_k_values, cos_scores_top_k_idx = metric.compute()
 
         # sort similar docs for each query by cosine similarity and keep only top_k
         sorted_idx = np.argsort(cos_scores_top_k_values, axis=0)[::-1]
@@ -195,6 +192,9 @@ class DenseRetrievalParallelExactSearch:
                     cos_scores_top_k_values, cos_scores_top_k_idx = torch.topk(cos_scores, min(self.top_k+1, len(cos_scores[1])), dim=1, largest=True, sorted=False)
                     cos_scores_top_k_values = cos_scores_top_k_values.T.unsqueeze(0).detach()
                     cos_scores_top_k_idx = cos_scores_top_k_idx.T.unsqueeze(0).detach()
+
+                    # correct sentence ids
+                    cos_scores_top_k_idx = cos_scores_top_k_idx + id * self.corpus_chunk_size
 
                     # Store results in an Apache Arrow table
                     metric.add_batch(cos_scores_top_k_values=cos_scores_top_k_values, cos_scores_top_k_idx=cos_scores_top_k_idx, batch_index=[id]*len(cos_scores_top_k_values))

--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -194,7 +194,7 @@ class DenseRetrievalParallelExactSearch:
                     cos_scores_top_k_idx = cos_scores_top_k_idx.T.unsqueeze(0).detach()
 
                     # correct sentence ids
-                    cos_scores_top_k_idx = cos_scores_top_k_idx + id * self.corpus_chunk_size
+                    cos_scores_top_k_idx += id * self.corpus_chunk_size
 
                     # Store results in an Apache Arrow table
                     metric.add_batch(cos_scores_top_k_values=cos_scores_top_k_values, cos_scores_top_k_idx=cos_scores_top_k_idx, batch_index=[id]*len(cos_scores_top_k_values))


### PR DESCRIPTION
Fixes https://github.com/beir-cellar/beir/issues/104

When gathering all results using `metric.compute` we sometimes mixed the batches ids. This PR aims to correct the documents ids when using DRPES.

Now DRPES gives correct results independently of how we set `corpus_chunk_size`
```python
>>> evaluation.run(model, output_folder=None, eval_splits=["test"], corpus_chunk_size=260)
Time taken to retrieve: 10.08 seconds
INFO:root:

INFO:root:NDCG@1: 0.2000
INFO:root:NDCG@3: 0.2567
INFO:root:NDCG@5: 0.2807
INFO:root:NDCG@10: 0.2953
INFO:root:NDCG@100: 0.3426
INFO:root:NDCG@1000: 0.3779
INFO:root:

INFO:root:MAP@1: 0.1867
INFO:root:MAP@3: 0.2366
INFO:root:MAP@5: 0.2505
INFO:root:MAP@10: 0.2574
INFO:root:MAP@100: 0.2660
INFO:root:MAP@1000: 0.2672
INFO:root:

INFO:root:Recall@1: 0.1867
INFO:root:Recall@3: 0.3019
INFO:root:Recall@5: 0.3581
INFO:root:Recall@10: 0.3994
INFO:root:Recall@100: 0.6336
INFO:root:Recall@1000: 0.9162
INFO:root:

INFO:root:P@1: 0.2000
INFO:root:P@3: 0.1078
INFO:root:P@5: 0.0787
INFO:root:P@10: 0.0443
INFO:root:P@100: 0.0070
INFO:root:P@1000: 0.0010
```

cc @Muennighoff @thakur-nandan 