### PR TITLE
ModuleNotFoundError

### DIFF
--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -2,7 +2,7 @@ from .util import cos_sim, dot_score
 from sentence_transformers import SentenceTransformer
 from torch.utils.data import DataLoader
 from datasets import Features, Value, Sequence
-from datasets.utils.filelock import FileLock
+from datasets.utils.file_utils import FileLock
 from datasets import Array2D, Dataset
 from tqdm.autonotebook import tqdm
 from datetime import datetime


### PR DESCRIPTION
When runnning this example,
[https://github.com/beir-cellar/beir/blob/main/examples/retrieval/evaluation/reranking/evaluate_bm25_ce_reranking.py](url)

I run into this error: `ModuleNotFoundError: No module named 'datasets.utils.filelock’` when FileLock gets imported in exact_search_multi_gpu.py script.

I thus edited the path in exact_search_multi_gpu.py that imports FileLock to the most updated path.