### PR TITLE
Check tf dependencies completely

### DIFF
--- a/beir/retrieval/models/use_qa.py
+++ b/beir/retrieval/models/use_qa.py
@@ -3,7 +3,9 @@ import importlib.util
 from typing import List, Dict
 from tqdm.autonotebook import trange
 
-if importlib.util.find_spec("tensorflow") is not None:
+if importlib.util.find_spec("tensorflow") is not None \
+    and importlib.util.find_spec("tensorflow_hub") is not None \
+    and importlib.util.find_spec("tensorflow_text") is not None:
     import tensorflow as tf
     import tensorflow_hub as hub
     import tensorflow_text


### PR DESCRIPTION
The code currently only checks the existence of `tensorflow` but something like `tensorflow-text`. However, if one goes to Google's Colab, where only `tensorflow` is installed, there will be an import error about `tensorflow-text`