### PR TITLE
Allow "show_progress_bar" and "convert_to_tensor" in `DenseRetrievalExactSearch`

### DIFF
--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -16,8 +16,8 @@ class DenseRetrievalExactSearch:
         self.score_functions = {'cos_sim': cos_sim, 'dot': dot_score}
         self.score_function_desc = {'cos_sim': "Cosine Similarity", 'dot': "Dot Product"}
         self.corpus_chunk_size = corpus_chunk_size
-        self.show_progress_bar = True #TODO: implement no progress bar if false
-        self.convert_to_tensor = True
+        self.show_progress_bar = kwargs.get('show_progress_bar', True)
+        self.convert_to_tensor = kwargs.get('convert_to_tensor', True)
         self.results = {}
     
     def search(self, 

--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -71,8 +71,8 @@ class DenseRetrievalParallelExactSearch:
         self.score_functions = {'cos_sim': cos_sim, 'dot': dot_score}
         self.score_function_desc = {'cos_sim': "Cosine Similarity", 'dot': "Dot Product"}
         self.corpus_chunk_size = corpus_chunk_size
-        self.show_progress_bar = True #TODO: implement no progress bar if false
-        self.convert_to_tensor = True
+        self.show_progress_bar = kwargs.get('show_progress_bar', True)
+        self.convert_to_tensor = kwargs.get('convert_to_tensor', True)
         self.results = {}
 
         self.query_embeddings = {}


### PR DESCRIPTION
This PR would allow enabling/disabling the progress bar when defining the `DRES` class, as well as specifying `convert_to_tensor` if needed.