### PR TITLE
Support Multi-node evaluation 

### DIFF
--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -4,7 +4,7 @@ from sentence_transformers import SentenceTransformer
 from torch.utils.data import DataLoader
 from datasets import Dataset
 from tqdm.autonotebook import tqdm
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import logging
 import torch
@@ -32,13 +32,13 @@ def main_rank_first(group: dist.ProcessGroup):
 # Abstract class is BaseSearch
 class DenseRetrievalParallelExactSearch(BaseSearch):
     
-    def __init__(self, model, batch_size: int = 128, corpus_chunk_size: int = 10000, **kwargs):
+    def __init__(self, model, batch_size: int = 128, corpus_chunk_size: Optional[int] = None, **kwargs):
         #model is class that provides encode_corpus() and encode_queries()
         self.model = model
         self.encoding_batch_size = batch_size
         self.score_functions = {'cos_sim': cos_sim, 'dot': dot_score}
         self.score_function_desc = {'cos_sim': "Cosine Similarity", 'dot': "Dot Product"}
-        self.corpus_chunk_size = corpus_chunk_size
+        self.corpus_chunk_size = batch_size * 100 if corpus_chunk_size is None else corpus_chunk_size
         self.show_progress_bar = kwargs.get("show_progress_bar", True) if int(os.getenv("RANK", 0)) == 0 else False
         self.convert_to_tensor = kwargs.get("convert_to_tensor", True)
         self.results = {}

--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -39,7 +39,7 @@ class DenseRetrievalParallelExactSearch(BaseSearch):
         self.score_functions = {'cos_sim': cos_sim, 'dot': dot_score}
         self.score_function_desc = {'cos_sim': "Cosine Similarity", 'dot': "Dot Product"}
         self.corpus_chunk_size = corpus_chunk_size
-        self.show_progress_bar = kwargs.get("show_progress_bar", True)
+        self.show_progress_bar = kwargs.get("show_progress_bar", True) if int(os.getenv("RANK", 0)) == 0 else False
         self.convert_to_tensor = kwargs.get("convert_to_tensor", True)
         self.results = {}
 

--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -17,10 +17,11 @@ import torch.distributed as dist
 logger = logging.getLogger(__name__)
 
 
-#Parent class for any dense model
+# parent class for any dense model that can be used for retrieval
+# Abstract class is BaseSearch
 class DenseRetrievalParallelExactSearch(BaseSearch):
     
-    def __init__(self, model, batch_size: int = 128, corpus_chunk_size: int = 10000, target_devices: List[str] = None, **kwargs):
+    def __init__(self, model, batch_size: int = 128, corpus_chunk_size: int = 10000, **kwargs):
         #model is class that provides encode_corpus() and encode_queries()
         self.model = model
         self.encoding_batch_size = batch_size

--- a/beir/retrieval/search/dense/exact_search_multi_gpu.py
+++ b/beir/retrieval/search/dense/exact_search_multi_gpu.py
@@ -239,7 +239,7 @@ class DenseRetrievalParallelExactSearch(BaseSearch):
         cos_scores_top_k_values = cos_scores_top_k_values.tolist()
         all_ranks_top_k_idx = all_ranks_top_k_idx.tolist()
         corpus_i_to_idx = corpus["id"]
-        for qid, top_k_values, top_k_idx in tqdm(zip(query_ids, cos_scores_top_k_values, all_ranks_top_k_idx), desc="Formatting results..."):
+        for qid, top_k_values, top_k_idx in zip(query_ids, cos_scores_top_k_values, all_ranks_top_k_idx):
             for score, corpus_i in zip(top_k_values, top_k_idx):
                 if corpus_i != qid: # WARNING: We remove the query from results if it exists in corpus
                     corpus_idx = corpus_i_to_idx[corpus_i]

--- a/examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
+++ b/examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
@@ -1,16 +1,15 @@
 '''
 This sample python shows how to evaluate BEIR dataset quickly using Mutliple GPU for evaluation (for large datasets).
-To run this code, you need Python >= 3.7 (not 3.6) and need to install evaluate library separately: ``pip install evaluate``
+To run this code, you need Python >= 3.7 (not 3.6)
 Enabling multi-gpu evaluation has been thanks due to tremendous efforts of Noumane Tazi (https://github.com/NouamaneTazi)
 
 IMPORTANT: The following code will not run with Python 3.6! 
 1. Please install Python 3.7 using Anaconda (conda create -n myenv python=3.7)
-2. Next, install Evaluate (https://github.com/huggingface/evaluate) using ``pip install evaluate``.
 
 You are good to go!
 
 To run this code, you preferably need access to mutliple GPUs. Faster than running on single GPU.
-CUDA_VISIBLE_DEVICES=0,1,2,3 python evaluate_sbert_multi_gpu.py
+CUDA_VISIBLE_DEVICES=0,1,2,3 torchrun --nproc_per_node=4 examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
 '''
 
 from beir.retrieval import models
@@ -26,8 +25,6 @@ import random
 import torch
 from torch import distributed as dist
 
-# Then use this command to run on 2 GPUs for example
-# torchrun --nproc_per_node=2 examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
 if __name__ == "__main__":
 
     # Initialize torch.distributed

--- a/examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
+++ b/examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
@@ -13,25 +13,21 @@ To run this code, you preferably need access to mutliple GPUs. Faster than runni
 CUDA_VISIBLE_DEVICES=0,1,2,3 python evaluate_sbert_multi_gpu.py
 '''
 
-from collections import defaultdict
-from beir import util, LoggingHandler
 from beir.retrieval import models
 from beir.datasets.data_loader_hf import HFDataLoader
-from beir.datasets.data_loader import GenericDataLoader
 from beir.retrieval.evaluation import EvaluateRetrieval
 from beir.retrieval.search.dense import DenseRetrievalParallelExactSearch as DRPES
-from beir.retrieval.search.dense import DenseRetrievalExactSearch as DRES
 import time
 
 import logging
-import pathlib, os
+import os
 import random
 
 import torch
 from torch import distributed as dist
 
 # Then use this command to run on 2 GPUs for example
-# torchrun --nproc_per_node=2 /fsx/nouamane/projects/beir/examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
+# torchrun --nproc_per_node=2 examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
 if __name__ == "__main__":
 
     # Initialize torch.distributed


### PR DESCRIPTION
You can try this PR using:
```
torchrun --nproc_per_node=2 examples/retrieval/evaluation/dense/evaluate_sbert_multi_gpu.py
```

Using `e5-large` model I got

- MSMARCO (8.84M documents) took 1h03min to encode (on 16 GPUs) -> evaluation took 1h04min
- NQ (2.68M documents) took 22min to encode (on 16 GPUs) -> evaluation took 25min

cc @thakur-nandan 

Fixes https://github.com/beir-cellar/beir/issues/134 