### PR TITLE
Evaluate "Offline" Models

### DIFF
--- a/beir/retrieval/search/dense/__init__.py
+++ b/beir/retrieval/search/dense/__init__.py
@@ -1,3 +1,3 @@
-from .exact_search import DenseRetrievalExactSearch 
+from .exact_search import DenseRetrievalExactSearch , DenseOfflineRetrievalExactSearch
 from .exact_search_multi_gpu import DenseRetrievalParallelExactSearch
 from .faiss_search import DenseRetrievalFaissSearch, BinaryFaissSearch, PQFaissSearch, HNSWFaissSearch, HNSWSQFaissSearch, FlatIPFaissSearch, PCAFaissSearch, SQFaissSearch

--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -8,8 +8,6 @@ import heapq
 
 logger = logging.getLogger(__name__)
 
-
-
 # DenseRetrievalExactSearch is parent class for any dense model that can be used for retrieval
 # Abstract class is BaseSearch
 class DenseRetrievalExactSearch(BaseSearch):

--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -20,7 +20,7 @@ class DenseRetrievalExactSearch(BaseSearch):
         self.score_function_desc = {'cos_sim': "Cosine Similarity", 'dot': "Dot Product"}
         self.corpus_chunk_size = corpus_chunk_size
         self.show_progress_bar = kwargs.get("show_progress_bar", True)
-        self.convert_to_tensor = kwargs.get("convert_to_tensor", False)
+        self.convert_to_tensor = kwargs.get("convert_to_tensor", True)
         self.results = {}
     
     def call_model_for_queries(self, queries, queries_ids=None):

--- a/beir/retrieval/search/dense/exact_search.py
+++ b/beir/retrieval/search/dense/exact_search.py
@@ -60,12 +60,7 @@ class DenseRetrievalExactSearch(BaseSearch):
             queries_strings.append(qs)
             queries_ids.append(qid)
             
-        query_embeddings = self.call_model_for_queries(queries_strings, queries_ids)
-        #with open("offline_model/queries.ids", "w") as f:
-        #    f.write("\n".join([str(x) for x in queries_ids]))
-        #np.save("offline_model/query.npy", query_embeddings.cpu().numpy())
-        
-          
+        query_embeddings = self.call_model_for_queries(queries_strings, queries_ids)          
         logger.info("Sorting Corpus by document length (Longest first)...")
 
         corpus_ids = sorted(corpus, key=lambda k: len(corpus[k].get("title", "") + corpus[k].get("text", "")), reverse=True)
@@ -83,10 +78,6 @@ class DenseRetrievalExactSearch(BaseSearch):
 
             # Encode chunk of corpus    
             sub_corpus_embeddings = self.call_model_for_subcorpus(corpus_start_idx, corpus_end_idx, corpus, corpus_ids)
-            #with open(f"offline_model/corpus{batch_num}.ids", "w") as f:
-            #    f.write("\n".join([str(x) for x in corpus_ids[corpus_start_idx:corpus_end_idx]]))
-            #np.save(f"offline_model/corpus{batch_num}.npy", sub_corpus_embeddings.cpu().numpy())
-
 
             # Compute similarites using either cosine-similarity or dot product
             cos_scores = self.score_functions[score_function](query_embeddings, sub_corpus_embeddings)

--- a/examples/retrieval/evaluation/dense/evaluate_offline_model.py
+++ b/examples/retrieval/evaluation/dense/evaluate_offline_model.py
@@ -13,12 +13,12 @@ import random
 
 class OfflineModel:
     def __init__(self, model_path=None, **kwargs):
-        self.model = None # ---> HERE Load your custom model
+        self.model = None # We don't use the model in offline mode 
+        # simply load the query, corpus and qrels
         self.query_npy = np.load(f"{model_path}/queries.npy")
         self.corpus_npy = np.load(f"{model_path}/corpus0.npy")
         self.query_ids = self.load_ids(f"{model_path}/queries.ids")
         self.corpus_ids = self.load_ids(f"{model_path}/corpus0.ids")
-        # self.model = SentenceTransformer(model_path)
     
     def load_ids(self, id_strs_path):
         id_strs = open(id_strs_path, 'r').read().splitlines()

--- a/examples/retrieval/evaluation/dense/evaluate_sbert.py
+++ b/examples/retrieval/evaluation/dense/evaluate_sbert.py
@@ -16,7 +16,7 @@ logging.basicConfig(format='%(asctime)s - %(message)s',
                     handlers=[LoggingHandler()])
 #### /print debug information to stdout
 
-dataset = "scifact"
+dataset = "trec-covid"
 
 #### Download nfcorpus.zip dataset and unzip the dataset
 url = "https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{}.zip".format(dataset)


### PR DESCRIPTION
Currently, beir evaluates a model by calling its encode_queries and encoder_corpus functions. These in turn call the `forward` methods of the model.

This works great for pytorch-based models, but not for models from other deep-learning frameworks.

To circumvent this issue, I've introduced a "general" offline model which is a static numpy array of query and corpus representations along with a mapping of desired corpus-ids for each query-id.

Thus, any model from any framework can dump its representations for queries and corpus in a numpy format which can then be evaluated using this PR.