### PR TITLE
replacing `pytrec_eval` with `pytrec-eval-terrier`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     python_requires='>=3.6',
     install_requires=[
         'sentence-transformers',
-        'pytrec_eval',
+        'pytrec-eval-terrier',
         'faiss_cpu',
         'elasticsearch==7.9.1',
         'datasets'


### PR DESCRIPTION
When replacing `pytrec_eval` with `pytrec-eval-terrier`, several installation issues of `pytrec_eval` can be effectively addressed. These issues include, but are not limited to:

1. **Compilation Failure**: The need for compilation during installation often leads to failures, as discussed in this Stack Overflow post: [https://stackoverflow.com/questions/74444484/pytrec-library-not-able-to-install-on-my-system-raising-error](https://stackoverflow.com/questions/74444484/pytrec-library-not-able-to-install-on-my-system-raising-error).
2. **Path Issues on Windows**: Installation failures on Windows due to path-related problems, as documented in this GitHub issue: [https://github.com/cvangysel/pytrec_eval/issues/32](https://github.com/cvangysel/pytrec_eval/issues/32).

By using `pytrec-eval-terrier`, these installation problems can be effectively mitigated, as demonstrated by the solution provided in this comment: [https://github.com/cvangysel/pytrec_eval/issues/32#issuecomment-2085306474](https://github.com/cvangysel/pytrec_eval/issues/32#issuecomment-2085306474).