### PR TITLE
BM25Search - Apply results dict updates after full query score calculation

### DIFF
--- a/beir/retrieval/search/lexical/bm25_search.py
+++ b/beir/retrieval/search/lexical/bm25_search.py
@@ -82,7 +82,8 @@ class BM25Search(BaseSearch):
                 for corpus_id, score in hit["hits"]:
                     if corpus_id != query_id:  # query doesnt return in results
                         scores[corpus_id] = score
-                    self.results[query_id] = scores
+                
+                self.results[query_id] = scores
 
         return self.results
 


### PR DESCRIPTION
For simplicity, seems like this update loop can be changed to apply the results dictionary only after all query scores are fully calculated.